### PR TITLE
remove unnecessary pkg-resources package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 nose==1.3.7
 numpy==1.11.3
-pkg-resources==0.0.0
 scipy==0.18.1


### PR DESCRIPTION
Looks like this might've snuck in due to a pip freeze bug in ubuntu:
https://github.com/pypa/pip/issues/4022
https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1635463

Was failing on OSX install.  I forked and was able to successfully install this package after removing this.

